### PR TITLE
Using Halide-to-Hardware master

### DIFF
--- a/scripts/build_halide_distrib.sh
+++ b/scripts/build_halide_distrib.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 source install_halide_deps.sh
-source install_and_build_halide.sh $1 $2
+source install_and_build_halide.sh
+#source install_and_build_halide.sh $1 $2
 cd Halide-to-Hardware
 rm -f distrib/halide.tgz
 rm -f distrib/libHalide.so

--- a/scripts/build_halide_distrib.sh
+++ b/scripts/build_halide_distrib.sh
@@ -2,7 +2,6 @@
 
 source install_halide_deps.sh
 source install_and_build_halide.sh
-#source install_and_build_halide.sh $1 $2
 cd Halide-to-Hardware
 rm -f distrib/halide.tgz
 rm -f distrib/libHalide.so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,5 @@ update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 source install_halide_deps.sh
 source install_garnet.sh
 source install_pre_built_halide.sh
-#source install_and_build_halide.sh StanfordAHA/Halide-to-Hardware hls_hwbuffer_codegen_garnetflow_updates
 
 date

--- a/scripts/install_and_build_halide.sh
+++ b/scripts/install_and_build_halide.sh
@@ -13,9 +13,9 @@ export LLVM_CONFIG=/usr/lib/llvm-7/bin/llvm-config
 export CLANG_OK=y
 
 # Get Halide
-git clone --branch hls_hwbuffer_codegen_garnetflow_updates --depth 1 https://github.com/$1
+#git clone --branch hls_hwbuffer_codegen_garnetflow_updates --depth 1 https://github.com/$1
 cd Halide-to-Hardware
-git checkout -qf $2
+#git checkout -qf $2
 
 make -j4
 make distrib

--- a/scripts/install_and_build_halide.sh
+++ b/scripts/install_and_build_halide.sh
@@ -13,9 +13,7 @@ export LLVM_CONFIG=/usr/lib/llvm-7/bin/llvm-config
 export CLANG_OK=y
 
 # Get Halide
-#git clone --branch hls_hwbuffer_codegen_garnetflow_updates --depth 1 https://github.com/$1
 cd Halide-to-Hardware
-#git checkout -qf $2
 
 make -j4
 make distrib

--- a/scripts/install_pre_built_halide.sh
+++ b/scripts/install_pre_built_halide.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-git clone --branch hls_hwbuffer_codegen_garnetflow_updates --depth 1 https://github.com/StanfordAHA/Halide-to-Hardware
+git clone --depth 1 https://github.com/StanfordAHA/Halide-to-Hardware
 cd Halide-to-Hardware
 
 wget -q https://github.com/StanfordAHA/Halide-to-Hardware/releases/download/cascade-cast-issue-resolved/halide_distrib.tgz


### PR DESCRIPTION
@jeffsetter @Kuree this pull request changes GarnetFlow so that it no longer uses the garnetflow_updates branch of Halide-to-Hardware, since that branch is now merged in to master.