### PR TITLE
Temporarily pin magma/mantle/fault versions

### DIFF
--- a/scripts/repo.json
+++ b/scripts/repo.json
@@ -9,11 +9,13 @@
         "name": "magma-lang",
         "type": "git",
         "url": "https://github.com/phanrahan/magma.git",
-        "branch": "master"
+        "branch": "v1.0.28"
     },
     {
         "name": "mantle",
-        "type": "pypi"
+        "type": "git",
+        "url": "https://github.com/phanrahan/mantle.git",
+        "branch": "v1.0.12"
     },
     {
         "name": "jmapper",
@@ -27,7 +29,7 @@
         "name": "fault",
         "type": "git",
         "url": "https://github.com/leonardt/fault",
-        "branch": "master"
+        "branch": "v2.0.23"
     },
         {
         "name": "pythunder",


### PR DESCRIPTION
Garnet/Gemstone need to be updated to magma 2.0.0