### PR TITLE
Pin peak/lassen commits

### DIFF
--- a/scripts/repo.json
+++ b/scripts/repo.json
@@ -61,13 +61,13 @@
         "name": "peak",
         "type": "git",
         "url": "https://github.com/phanrahan/peak",
-        "branch": "master"
+        "branch": "e958ab4996a49ff19d2c2ed5bdfcffc02a69eb36"
     },
     {
         "name": "lassen",
         "type": "git",
         "url": "https://github.com/StanfordAHA/lassen",
-        "branch": "master"
+        "branch": "b81035a79182fb075e11dac11c45b2ad1d3d218e"
     },
     {
         "name": "metamapper",


### PR DESCRIPTION
Peak and lassen are about to be updated to magma 2.0.

I propose that we pin these repos until garnet is up to date, then we submit a PR that reverts these repos back to master/releases to verify that garnet flow is up to date with the latest changes.