### PR TITLE
Remove old pycoreir pin

### DIFF
--- a/scripts/install_garnet.sh
+++ b/scripts/install_garnet.sh
@@ -1,7 +1,4 @@
 
-# pin pycoreir version since the latest one doesn't work
-pip3 install --ignore-installed coreir==2.0.19
-
 # install this last since we already have a coreir built
 python3 python_repo.py
 


### PR DESCRIPTION
This shouldn't be necessary anymore, and, in fact, I don't think it's actually doing anything since a newer version of coreir is installed later (required for magma)