### PR TITLE
Update coreir branch

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -40,9 +40,7 @@ $1: $(addprefix /tmp/, $1.bs.out)
 	make -C $(HALIDE_DIR)/$2/$1 bin/output_cpu.raw && cp $(HALIDE_DIR)/$2/$1/bin/output_cpu.raw /tmp/$1_gold.raw
 	cp $(HALIDE_DIR)/$2/$1/bin/design_top.json /tmp/$1_lakelib.json
 	./build_coreir_cleaner.sh /tmp/$1_lakelib.json
-	cd BufferMapping/script; python coreir_gen.py /tmp/$1_lakelib.json; cp ./output/$1_lakelib_rewrite.json /tmp/$1_lakelib_lowered.json
-	./replace_lakelib_with_commonlib.sh /tmp/$1_lakelib_lowered.json > /tmp/$1_commonlib.json
-	./replace_numbered_datain_dataout.sh /tmp/$1_commonlib.json > /tmp/$1.json
+	cd BufferMapping/script; python coreir_gen.py /tmp/$1_lakelib.json; cp ./output/$1_lakelib_rewrite.json /tmp/$1.json
 endef
 
 $(foreach app, $(APPS), $(eval $(call make-test,$(app),apps)))

--- a/scripts/build_coreir_cleaner.sh
+++ b/scripts/build_coreir_cleaner.sh
@@ -1,6 +1,6 @@
 COREIR_DIR=/GarnetFlow/scripts/coreir
 BUFFERLIB_DIR=/GarnetFlow/scripts/BufferMapping
-COREIR_LD_FLAGS="-L$COREIR_DIR/lib -Wl,-rpath,$COREIR_DIR/lib -lcoreir-commonlib -lcoreir -lcoreirsim -lcoreir-float -L$BUFFERLIB_DIR/cfunc/bin -lfuncubuf"
+COREIR_LD_FLAGS="-L$COREIR_DIR/lib -Wl,-rpath,$COREIR_DIR/lib -lcoreir-commonlib -lcoreir -lcoreirsim -lcoreir-float -L$BUFFERLIB_DIR/cfunc/bin -lcoreir-lakelib"
 #-Wl,-rpath $COREIR_DIR/lib
 
 #rm -f coreir_cleaner

--- a/scripts/build_coreir_cleaner.sh
+++ b/scripts/build_coreir_cleaner.sh
@@ -5,7 +5,7 @@ COREIR_LD_FLAGS="-L$COREIR_DIR/lib -Wl,-rpath,$COREIR_DIR/lib -lcoreir-commonlib
 
 #rm -f coreir_cleaner
 echo "Compiling..."
-cmd="g++ coreir_interface_cleaner.cpp -I $BUFFERLIB_DIR/cfunc/include -I ./coreir/include/ $COREIR_LD_FLAGS -o coreir_cleaner"
+cmd="g++ -std=c++17 coreir_interface_cleaner.cpp -I $BUFFERLIB_DIR/cfunc/include -I ./coreir/include/ $COREIR_LD_FLAGS -o coreir_cleaner"
 echo "Cmd = $cmd"
 eval $cmd
 echo "done compiling..."

--- a/scripts/install_halide_deps.sh
+++ b/scripts/install_halide_deps.sh
@@ -8,7 +8,7 @@ if [ ! -d "coreir" ]; then
 	# test of push ability
 	# build coreir here
 	#git clone --depth 1 --branch rm-ubuf https://github.com/rdaly525/coreir coreir
-	git clone --depth 1 --branch ubuffer https://github.com/rdaly525/coreir coreir
+	git clone --depth 1 --branch rm-ubuf-master https://github.com/rdaly525/coreir coreir
 	# there is a bug in ABI with regex
 	# see https://github.com/rdaly525/coreir/issues/737
 	#cd coreir && \

--- a/scripts/replace_lakelib_with_commonlib.sh
+++ b/scripts/replace_lakelib_with_commonlib.sh
@@ -1,2 +1,0 @@
-awk '{gsub("lakelib", "commonlib", $0); print}' $1
-

--- a/scripts/replace_numbered_datain_dataout.sh
+++ b/scripts/replace_numbered_datain_dataout.sh
@@ -1,2 +1,0 @@
-awk '{gsub("datain0", "datain.0", $0); print}' $1 > /tmp/dout_tmp.json
-awk '{gsub("dataout0", "dataout.0", $0); print}' /tmp/dout_tmp.json


### PR DESCRIPTION
Update coreir branch to the one without unified buffer library directly in coreir. Unified buffer is now in lake lib.